### PR TITLE
fix wrong wasmplus amino codec register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [\#8](https://github.com/line/wasmd/pull/8) Bump line/lbm-sdk to a7557b1d10
 
 ### Bug Fixes
+* [\#12](https://github.com/line/wasmd/pull/12) fix not to register wrong codec in `x/wasmplus`
 
 ### Breaking Changes
 

--- a/x/wasmplus/types/codec.go
+++ b/x/wasmplus/types/codec.go
@@ -16,7 +16,7 @@ import (
 
 // RegisterLegacyAminoCodec registers the account types and interface
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) { //nolint:staticcheck
-	legacy.RegisterAminoMsg(cdc, &MsgStoreCodeAndInstantiateContract{}, "wasm/StoreCodeAndInstantiateContract")
+	legacy.RegisterAminoMsg(cdc, &MsgStoreCodeAndInstantiateContract{}, "wasm/MsgStoreCodeAndInstantiateContract")
 
 	cdc.RegisterConcrete(&DeactivateContractProposal{}, "wasm/DeactivateContractProposal", nil)
 	cdc.RegisterConcrete(&ActivateContractProposal{}, "wasm/ActivateContractProposal", nil)

--- a/x/wasmplus/types/tx.go
+++ b/x/wasmplus/types/tx.go
@@ -3,12 +3,10 @@ package types
 import (
 	sdk "github.com/line/lbm-sdk/types"
 	sdkerrors "github.com/line/lbm-sdk/types/errors"
-
-	wasmtypes "github.com/line/wasmd/x/wasm/types"
 )
 
 func (msg MsgStoreCodeAndInstantiateContract) Route() string {
-	return wasmtypes.RouterKey
+	return RouterKey
 }
 
 func (msg MsgStoreCodeAndInstantiateContract) Type() string {
@@ -51,7 +49,7 @@ func (msg MsgStoreCodeAndInstantiateContract) ValidateBasic() error {
 }
 
 func (msg MsgStoreCodeAndInstantiateContract) GetSignBytes() []byte {
-	return sdk.MustSortJSON(wasmtypes.ModuleCdc.MustMarshalJSON(&msg))
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
 }
 
 func (msg MsgStoreCodeAndInstantiateContract) GetSigners() []sdk.AccAddress {

--- a/x/wasmplus/types/tx_test.go
+++ b/x/wasmplus/types/tx_test.go
@@ -143,14 +143,26 @@ func TestMsgJsonSignBytes(t *testing.T) {
 		src legacytx.LegacyMsg
 		exp string
 	}{
-		"MsgInstantiateContract": {
-			src: &MsgStoreCodeAndInstantiateContract{Sender: "sender1", WASMByteCode: []byte{89, 69, 76, 76, 79, 87, 32, 83, 85, 66, 77, 65, 82, 73, 78, 69}, Admin: "admin1", Label: "My", Msg: wasmTypes.RawContractMessage(myInnerMsg)},
+		"MsgInstantiateContract with every field": {
+			src: &MsgStoreCodeAndInstantiateContract{Sender: "sender1", WASMByteCode: []byte{89, 69, 76, 76, 79, 87, 32, 83, 85, 66, 77, 65, 82, 73, 78, 69},
+				InstantiatePermission: &wasmTypes.AccessConfig{Permission: wasmTypes.AccessTypeAnyOfAddresses, Addresses: []string{"address1", "address2"}},
+				Admin:                 "admin1", Label: "My", Msg: wasmTypes.RawContractMessage(myInnerMsg), Funds: sdk.Coins{{Denom: "denom1", Amount: sdk.NewInt(1)}}},
 			exp: `
 {
 	"type":"wasm/MsgStoreCodeAndInstantiateContract",
-	"value": {"admin":"admin1","funds":[],"label":"My","msg": {"foo":"bar"},"sender":"sender1","wasm_byte_code":"WUVMTE9XIFNVQk1BUklORQ=="}
+	"value": {"admin":"admin1","funds":[{"amount":"1","denom":"denom1"}],"instantiate_permission":{"addresses":["address1","address2"],
+		"permission":"AnyOfAddresses"},"label":"My","msg":{"foo":"bar"},"sender":"sender1","wasm_byte_code":"WUVMTE9XIFNVQk1BUklORQ=="}
 }`,
-		}}
+		},
+		"MsgInstantiateContract with minimum field": {
+			src: &MsgStoreCodeAndInstantiateContract{},
+			exp: `
+{
+	"type":"wasm/MsgStoreCodeAndInstantiateContract",
+	"value": {"funds":[]}
+}`,
+		},
+	}
 	for name, spec := range specs {
 		t.Run(name, func(t *testing.T) {
 			bz := spec.src.GetSignBytes()

--- a/x/wasmplus/types/tx_test.go
+++ b/x/wasmplus/types/tx_test.go
@@ -3,13 +3,13 @@ package types
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/line/lbm-sdk/x/auth/legacy/legacytx"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/line/lbm-sdk/types"
+	"github.com/line/lbm-sdk/x/auth/legacy/legacytx"
 
 	wasmTypes "github.com/line/wasmd/x/wasm/types"
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
closes: #11 

1. When registering wasmplus amino codec, wrong message type name registered. currently "wasm/StoreCodeAndInstantiateContract", this should be "wasm/MsgStoreCodeAndInstantiateContract" like other messages.
2. When MsgStoreCodeAndInstantiateContract:: GetSignBytes is called wrong codec was called. currently wasm's codec is called which MsgStoreCodeAndInstantiateContract is not registered. wasmplus codec should be used.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`