### PR TITLE
fix: fix the cmd error that does not recognize wasmvm library version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [\#10](https://github.com/line/wasmd/pull/10) update wasmvm version
 
 ### Bug Fixes
+* [\#14](https://github.com/line/wasmd/pull/14) fix the cmd error that does not recognize wasmvm library version
 
 ### Breaking Changes
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/line/ibc-go/v3 v3.3.2-0.20230210040007-d855e1d87f26
 	github.com/line/lbm-sdk v0.46.1-0.20230209105703-b88647308597
 	github.com/line/ostracon v1.0.9-0.20230209043112-5aca894db3a6
-	github.com/line/wasmvm v1.1.1-0.11.1
+	github.com/line/wasmvm v1.1.1-0.11.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/rakyll/statik v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -421,8 +421,8 @@ github.com/line/lbm-sdk v0.46.1-0.20230209105703-b88647308597 h1:J0Pr378D5JmHNji
 github.com/line/lbm-sdk v0.46.1-0.20230209105703-b88647308597/go.mod h1:Od+QeMi4JO4HB3HEdPTqzI7mAvn1w99PZ9pmKmtNDco=
 github.com/line/ostracon v1.0.9-0.20230209043112-5aca894db3a6 h1:nuM0PTB04PCax35+u8LRpTufdmwoPZcBhhKjqbezMYA=
 github.com/line/ostracon v1.0.9-0.20230209043112-5aca894db3a6/go.mod h1:iLRth/ryufyNePzJ1ULJ4S8SYGUD/lF+aIFUTRKY9tQ=
-github.com/line/wasmvm v1.1.1-0.11.1 h1:W3fuNZyQYm+fyXV4n6Ds8pzmHLyYcgv5gXgQf42ofi8=
-github.com/line/wasmvm v1.1.1-0.11.1/go.mod h1:Lq3FVvi/rb+OOlTxqtcqcao2GGESQ4hUpuXMcjdJbco=
+github.com/line/wasmvm v1.1.1-0.11.2 h1:dkwlXSBXQR4aEP8B7RkN4TXqjFbsB2QHPYtsJKlNHmQ=
+github.com/line/wasmvm v1.1.1-0.11.2/go.mod h1:Lq3FVvi/rb+OOlTxqtcqcao2GGESQ4hUpuXMcjdJbco=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=

--- a/x/wasm/module.go
+++ b/x/wasm/module.go
@@ -257,7 +257,7 @@ func getExpectedLibwasmVersion() string {
 		panic("can't read build info")
 	}
 	for _, d := range buildInfo.Deps {
-		if d.Path != "github.com/CosmWasm/wasmvm" {
+		if d.Path != "github.com/line/wasmvm" {
 			continue
 		}
 		if d.Replace != nil {

--- a/x/wasm/module_test.go
+++ b/x/wasm/module_test.go
@@ -592,3 +592,7 @@ func assertContractInfo(t *testing.T, q sdk.Querier, ctx sdk.Context, contractBe
 	assert.Equal(t, codeID, res.CodeID)
 	assert.Equal(t, creator.String(), res.Creator)
 }
+
+func TestCheckLlibwasmVersion(t *testing.T) {
+	assert.NoError(t, checkLibwasmVersion(nil, []string{}))
+}

--- a/x/wasm/module_test.go
+++ b/x/wasm/module_test.go
@@ -592,7 +592,3 @@ func assertContractInfo(t *testing.T, q sdk.Querier, ctx sdk.Context, contractBe
 	assert.Equal(t, codeID, res.CodeID)
 	assert.Equal(t, creator.String(), res.Creator)
 }
-
-func TestCheckLlibwasmVersion(t *testing.T) {
-	assert.NoError(t, checkLibwasmVersion(nil, []string{}))
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
closes: #13 

fix the cmd error that does not recognize wasmvm library version.


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When we run the wasmd cli, `Error: wasmvm module not exist` is always displayed. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If any of the checklist items are not applicable, leave it `[ ]` and write a little note why. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/lbm-sdk/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/line/lbm-sdk/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added a relevant changelog to `CHANGELOG.md`
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated API documentation `client/docs/swagger-ui/swagger.yaml`